### PR TITLE
Modified the write_to_data_file to handle data not reported more gracefu...

### DIFF
--- a/mikoomi-mongodb-plugin.php
+++ b/mikoomi-mongodb-plugin.php
@@ -183,10 +183,10 @@ if (!isset($server_status['ok'])) {
 }
 
 $mongo_version = $server_status['version'] ;
-write_to_data_file($zabbix_name, "mongodb_version $mongo_version") ;
+write_to_data_file($zabbix_name, "mongodb_version", $mongo_version) ;
 
 $uptime = $server_status['uptime'] ;
-write_to_data_file($zabbix_name, "uptime $uptime") ;
+write_to_data_file($zabbix_name, "uptime", $uptime) ;
 
 $globalLock_lockTime = $server_status['globalLock']['lockTime'] ;
 write_to_data_file($zabbix_name, "globalLock_lockTime", $globalLock_lockTime) ;


### PR DESCRIPTION
...lly. Essentially if the data value is not there, it's not submitted to Zabbix. Second change done was related to the Zabbix host name. If the Zabbix host name had any spaces in it, the script would fail. It would not write the correct data and log file name or the correct Zabbix name inside the data file.
